### PR TITLE
Replace the old slack sdk with the new one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ boto3
 requests
 maestroops
 datadog
-slackclient
+slack-sdk
 pyyaml
 dnspython3
-pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ requests
 maestroops
 datadog
 slack-sdk
+slackclient
 pyyaml
 dnspython3


### PR DESCRIPTION
Aside from adding the new slack sdk to requirements.txt, this removes one of the pyyamls that were in there. Note that the old slack sdk was not removed for backwards compatibility purposes.