### PR TITLE
Change slack-sdk to slack_sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto3
 requests
 maestroops
 datadog
-slack-sdk
+slack_sdk
 slackclient
 pyyaml
 dnspython3


### PR DESCRIPTION
The PyPI page has a blatant lie in font size 40 at the top of the page regarding the installation of slack-sdk. The name of the package is actually supposed to be slack_sdk and not slack-sdk. This fixes that.